### PR TITLE
Evaluates path correctly in --output param

### DIFF
--- a/openshift2nulecule/cli/main.py
+++ b/openshift2nulecule/cli/main.py
@@ -57,7 +57,7 @@ class CLI():
             logger.critical(msg)
             raise Exception(msg)
 
-        nulecule_dir = utils.get_path(os.path.abspath(args.output))
+        nulecule_dir = utils.get_path(args.output)
 
         if os.path.exists(nulecule_dir):
             msg = "{} must not exist".format(nulecule_dir)

--- a/openshift2nulecule/utils.py
+++ b/openshift2nulecule/utils.py
@@ -46,6 +46,11 @@ def get_path(path):
         str: path with prefixed /host if inside container
     """
     if in_container():
-        return HOST_DIR + path
+        return HOST_DIR + os.path.abspath(path)
     else:
-        return path
+        expanded_path = os.path.expanduser(path)
+        if os.path.isabs(expanded_path):
+            return expanded_path
+        else:
+            return os.path.abspath(expanded_path)
+


### PR DESCRIPTION
Earlier the relative paths using tilde was not being evaluated
correctly rather a new dir was created with tilde sign name
but now tilde is evaluated as user home and relative path works
with respect to current folder.

Fixes issue #3