### PR TITLE
rpm spec: fix build directory name for autosetup

### DIFF
--- a/openshift2nulecule.spec
+++ b/openshift2nulecule.spec
@@ -23,7 +23,7 @@ This tool is creating new Nulecule application with Kubernetes artifacts
 from OpenShift project.
 
 %prep
-%autosetup -n %{name}-%{commit0}
+%autosetup -n %{name}-%{version}
 
 %build
 %py2_build
@@ -40,6 +40,9 @@ rm -rf $RPM_BUILD_ROOT
 %{_bindir}/openshift2nulecule
 
 %changelog
+* Tue Mar 1 2016 Tomas Kral <tkral@redhat.com> 0.0.2-3
+- fix build direcotry name for autosetup
+
 * Wed Feb 17 2016 Tomas Kral <tkral@redhat.com> 0.0.2-2
 - update source - direct link to github
 


### PR DESCRIPTION
fixes #16 

I tested it using :
```sh
mock -r epel-7-x86_64 --scm-enable \ 
  --scm-option method=git \
  --scm-option package=openshift2nulecule \
  --scm-option git_get=set \
  --scm-option spec=openshift2nulecule.spec \
  --scm-option branch=fix-spec \
  --scm-option write_tar=True \
  --scm-option git_get='git clone https://github.com/kadel/openshift2nulecule'
```