### PR TITLE
Mount docker.socket to container. Fixes #22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,14 @@
-FROM centos:7
+FROM fedora:23
 
 MAINTAINER Tomas Kral <tkral@redhat.com>
 
-LABEL RUN="docker run -it --rm \${OPT1} --privileged --user=\${SUDO_UID}:\${SUDO_GID} -v /:/host --net=host --name \${NAME} \${IMAGE}"
+LABEL RUN="docker run -it --rm \${OPT1} --privileged -v /var/run/docker.sock:/var/run/docker.sock -v /:/host --net=host --name \${NAME} \${IMAGE}"
 
 ADD requirements.txt ./
 
-RUN yum install -y epel-release && \
-    yum install -y --setopt=tsflags=nodocs docker && \
-    yum install -y --setopt=tsflags=nodocs $(sed s/^/python-/ requirements.txt) && \
-    yum clean all
+# requires python-docker-py >= 1.6.0 that is only in testing
+RUN dnf install -y --setopt=tsflags=nodocs --enablerepo=updates-testing $(sed s/^/python-/ requirements.txt) && \
+    dnf clean all
 
 ENV PYTHONPATH  /opt/openshift2nulecule/
 

--- a/README.md
+++ b/README.md
@@ -100,17 +100,26 @@ Easies way how to run openshift2nulecule as Docker container is to use [Atomic](
 atomic run tomaskral/openshift2nulecule \
   --project testing \
   --output $HOME/mytest \
-  --oc-config=$HOME/.kube/config
+  --oc-config=$HOME/.kube/config \
+  --oc-registry-host 172.30.22.38:5000 \
+  --export-images all \
+  --registry-host my_registry:5000
 ```
 When you are running openshift2nulecule from container, you have to always specify path to `oc` configuration file (`--oc-config`)
 in most cases setting it to default `$HOME/.kube/config` should be enough.
 
 Example of running openshift2nulecule container without Atomic tool:
 ```sh
-docker run -it --rm --privileged --net=host -v /:/host tomaskral/openshift2nulecule \
+docker run -it --rm --privileged --net=host \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  -v /:/host \
+  tomaskral/openshift2nulecule \
   --project testing \
   --output $HOME/mytest \
   --oc-config=$HOME/.kube/config
+  --oc-registry-host 172.30.22.38:5000 \
+  --export-images all \
+  --registry-host my_registry:5000
 
 ```
 


### PR DESCRIPTION
For image export to work inside docker container we need to mount docker.socket inside so it is possible to call docker pull/push