### PR TITLE
Replace oc export all with specific object types

### DIFF
--- a/openshift2nulecule/openshift.py
+++ b/openshift2nulecule/openshift.py
@@ -117,7 +117,8 @@ class OpenshiftClient(object):
                              "persistentvolumeclaims",
                              "services"]
             elif provider == "openshift":
-                resources = ["all"]
+                resources = ["service", "deploymentConfig", "buildConfig",
+                             "imageStream", "route"]
 
             # output of this export is kind List
             args = ["export", ",".join(resources), "-o", "json"]


### PR DESCRIPTION
While exporting openshift artifacts specific object types are provided. This reduces the bugs introduced by exporting incompatible objects.

Fixes issue #33