### PR TITLE
Add --skip-push option

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,13 @@ Arguments related to exporting images:
                       (if it is required)
 
 
-Example:
+Following example will pull all images that are used in project and  will push them to `localhost:5000` registry.
 ```sh
 openshift2nulecule --project mlb --output ./myapp --oc-registry-host docker-registry.cdk.10.2.2.2.xip.io --export-images all --registry-host localhost:5000 
 ```
 
+For testing you might want to skip push stage. You can do this by adding `--skip-push` option.
+With this option openshift2nulecule will only pull images to you local docker instance.
 
 # Installation
 RPMs: https://copr.fedorainfracloud.org/coprs/tkral/openshift2nulecle/

--- a/openshift2nulecule/cli/main.py
+++ b/openshift2nulecule/cli/main.py
@@ -69,6 +69,10 @@ class CLI():
                                  help="Login information for the external registry (if required) "
                                       "(username:passoword)",
                                  required=False)
+        self.parser.add_argument("--skip-push",
+                                 help="Don't push images to external registry. (usefull for testing)",
+                                 action='store_true')
+
 
     def run(self):
         args = self.parser.parse_args()
@@ -82,8 +86,8 @@ class CLI():
             logger.critical(msg)
             raise Exception(msg)
 
-        if args.export_images != 'none' and not args.registry_host:
-            msg = "With --export-images you need also set --registry-host"
+        if not args.skip_push and args.export_images != 'none' and not args.registry_host:
+            msg = "With --export-images you also need set --registry-host. If you don't want to push images to registry, you have to use --skip-push"
             logger.critical(msg)
             raise Exception(msg)
 
@@ -130,8 +134,8 @@ class CLI():
                                                       oc.get_token(),
                                                       only_internal)
 
-            # if registy-host is not set do not perform push
-            if args.registry_host:
+            # if registy-host is not set or skip-push is set do not perform push
+            if args.registry_host and not args.skip_push:
                 exported_project['openshift'].push_images(args.registry_host,
                                                           registry_user,
                                                           registry_password,


### PR DESCRIPTION
If --skip-push is set  images are only pulled to local Docker instance.
This is useful for testing.