### PR TITLE
Added an option for custom Atomic App version

### DIFF
--- a/openshift2nulecule/cli/main.py
+++ b/openshift2nulecule/cli/main.py
@@ -6,7 +6,8 @@ import argparse
 import logging
 import anymarkup
 
-from openshift2nulecule.constants import NULECULE_PROVIDERS
+from openshift2nulecule.constants import (NULECULE_PROVIDERS,
+                                          ATOMICAPP_VERSION)
 from openshift2nulecule.openshift import OpenshiftClient
 from openshift2nulecule import utils
 
@@ -68,6 +69,12 @@ class CLI():
         self.parser.add_argument("--registry-login",
                                  help="Login information for the external registry (if required) "
                                       "(username:passoword)",
+                                 required=False)
+
+        self.parser.add_argument("--atomicapp-ver",
+                                 help="Specify custom Atomic App version for the Dockerfile that will be generated.",
+                                 type=str,
+                                 default=ATOMICAPP_VERSION,
                                  required=False)
 
     def run(self):
@@ -169,7 +176,7 @@ class CLI():
                                "artifacts": provider_artifacts}]}
         anymarkup.serialize_file(nulecule, nulecule_file, format="yaml")
 
-        utils.generate_dockerfile(nulecule_dir)
+        utils.generate_dockerfile(nulecule_dir, args.atomicapp_ver)
         logger.info("Nulecule application created in {}".format(
             utils.remove_path(nulecule_dir)))
 

--- a/openshift2nulecule/utils.py
+++ b/openshift2nulecule/utils.py
@@ -5,8 +5,7 @@ import logging
 import itertools
 from openshift2nulecule.constants import (HOST_DIR,
                                           NULECULE_SPECVERSION,
-                                          NULECULE_PROVIDERS,
-                                          ATOMICAPP_VERSION)
+                                          NULECULE_PROVIDERS)
 import ipaddress
 
 logger = logging.getLogger(__name__)
@@ -64,15 +63,26 @@ def get_path(path):
             return os.path.abspath(expanded_path)
 
 
-def generate_dockerfile(nulecule_dir):
+def generate_dockerfile(nulecule_dir, atomicapp_version):
+    """
+    Generate a Dockerfile for an exported application automatically, by
+    reading the contents of the directory where the exported artifacts reside.
 
+    Args:
+        nulecule_dir (str): path to the directory where all Nulecule artifacts
+                            reside
+        atomicapp_version (str): Atomic App version to be used in Dockerfile.
+
+    Returns:
+        None
+    """
     files = [file for file in os.listdir(nulecule_dir)
              if os.path.isfile(os.path.join(nulecule_dir, file))]
     files.append('Dockerfile')
     dockerfile = open(os.path.join(nulecule_dir, 'Dockerfile'), 'w')
 
     dockerfile.writelines([
-        'FROM projectatomic/atomicapp:{}\n'.format(ATOMICAPP_VERSION),
+        'FROM projectatomic/atomicapp:{}\n'.format(atomicapp_version),
         '\n',
         'LABEL io.projectatomic.nulecule.providers="{}" \\\n'.format(
             ','.join(NULECULE_PROVIDERS)),


### PR DESCRIPTION
Now user can use `--atomicapp-ver` to specify the Atomic App version user wants in the automatically generated Dockerfile. So user is not locked into the Atomic App version in constants file.

Fixes issue #26