### PR TITLE
Add ReplicationController to list of objects that are exported from OpenShift

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ artifacts from OpenShift project.
 
 ## Limitations
  - Exports only `ReplicationControllers`, `PersistentVolumeClaims`, `Services` for *Kubernetes*.
- - Exports only `service`, `deploymentConfig`, `buildConfig`, `imageStream`, `route` for *Openshift*, other objects like `build`, `imageStreamTag`, `imageStreamImage`, `event`, `node`, `pod`, `replicationController`, `persistentVolume`, `persistentVolumeClaim` are not exported at the moment.
+ - Exports only `service`, `deploymentConfig`, `buildConfig`, `imageStream`, `route`, `replicationController`, `persistentVolumeClaim` for *Openshift*, other objects like `build`, `imageStreamTag`, `imageStreamImage`, `event`, `node`, `pod`, `persistentVolume`,  are not exported at the moment.
  - Everything is exported as single artifacts containing everything.
  - ~~If you have images in internal OpenShift Docker registry,
 you have to manually export them to accessible registry and update artifact.~~

--- a/openshift2nulecule/openshift.py
+++ b/openshift2nulecule/openshift.py
@@ -113,12 +113,17 @@ class OpenshiftClient(object):
         exported_project = {}
         for provider in NULECULE_PROVIDERS:
             if provider == "kubernetes":
-                resources = ["replicationcontrollers",
-                             "persistentvolumeclaims",
-                             "services"]
+                resources = ["replicationController",
+                             "persistentVolumeClaim",
+                             "service"]
             elif provider == "openshift":
-                resources = ["service", "deploymentConfig", "buildConfig",
-                             "imageStream", "route"]
+                resources = ["replicationController",
+                             "deploymentConfig",
+                             "buildConfig",
+                             "imageStream",
+                             "service",
+                             "persistentVolumeClaim",
+                             "route"]
 
             # output of this export is kind List
             args = ["export", ",".join(resources), "-o", "json"]


### PR DESCRIPTION
I tested this and for all apps (mlbparks, hexboard, ruby hello world) I tested it is working OK.
It gets paired with DeploymentConfig if there is one for given RC