### PR TITLE
Now export only the app that is required

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,19 @@ If you need pass `--config` option to `oc` binary, you can do that using `--oc-c
 # Usage
 Before running this you have to be authenticated to OpenShift using `oc login` command. (see [Basic Setup and Login](https://docs.openshift.com/enterprise/3.0/cli_reference/get_started_cli.html#basic-setup-and-login)).
 
+- Export whole project
+
 ```sh
 openshift2nulecule --output=/path/to/new/myapp --project=myproject
 ```
 This will export whole project `myproject` from OpenShift
 and create new Nulecule application in `/path/to/new/myapp` directory.
+
+- Selectively export an application
+
+```bash
+openshift2nulecule --project hexboard --output ~/exported/hexboard --selector app=sketchpod
+```
 
 ## Exporting images from OpenShift
 This tool has also support for exporting images from internal OpenShift Docker registry.

--- a/openshift2nulecule/cli/main.py
+++ b/openshift2nulecule/cli/main.py
@@ -74,11 +74,17 @@ class CLI():
                                  help="Don't push images to external registry. (usefull for testing)",
                                  action='store_true')
 
-
         self.parser.add_argument("--atomicapp-ver",
                                  help="Specify custom Atomic App version for the Dockerfile that will be generated.",
                                  type=str,
                                  default=ATOMICAPP_VERSION,
+                                 required=False)
+
+        self.parser.add_argument("--selector",
+                                 help="Specify it in the form key=value, the only configuration that matches this will\n"
+                                      "be exported. This helps you to select app from the multiple apps deployed in a\n"
+                                      "single project.",
+                                 type=str,
                                  required=False)
 
     def run(self):
@@ -124,7 +130,8 @@ class CLI():
 
         oc = OpenshiftClient(oc=args.oc,
                              namespace=args.project,
-                             oc_config=args.oc_config)
+                             oc_config=args.oc_config,
+                             selector=args.selector)
 
         # export project info from openshift
         exported_project = oc.export_project()

--- a/openshift2nulecule/openshift.py
+++ b/openshift2nulecule/openshift.py
@@ -18,13 +18,15 @@ class OpenshiftClient(object):
     namespace = None
     oc_config = None
 
-    def __init__(self, oc=None, namespace=None, oc_config=None):
+    def __init__(self, oc=None, namespace=None, oc_config=None,
+                 selector=None):
         if oc:
             self.oc = oc
         else:
             self.oc = self._find_oc()
 
         self.namespace = namespace
+        self.selector = selector
 
         if oc_config:
             self.oc_config = utils.get_path(oc_config)
@@ -127,6 +129,10 @@ class OpenshiftClient(object):
 
             # output of this export is kind List
             args = ["export", ",".join(resources), "-o", "json"]
+            # if user has specified the selector append it to command
+            if self.selector:
+                args.extend(["-l", self.selector])
+
             ec, stdout, stderr = self._call_oc(args)
             objects = anymarkup.parse(stdout, format="json", force_types=None)
 


### PR DESCRIPTION
Added an option called as `--label-selector`, which acts as a filter using which only specific app can be exported, rather than exporting all the apps in the project.

Fixes issue #40