### PR TITLE
Stop exporting routes from OpenShift.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ artifacts from OpenShift project.
 
 ## Limitations
  - Exports only `ReplicationControllers`, `PersistentVolumeClaims`, `Services` for *Kubernetes*.
- - Exports only `service`, `deploymentConfig`, `buildConfig`, `imageStream`, `route`, `replicationController`, `persistentVolumeClaim` for *Openshift*, other objects like `build`, `imageStreamTag`, `imageStreamImage`, `event`, `node`, `pod`, `persistentVolume`,  are not exported at the moment.
+ - Exports only `service`, `deploymentConfig`, `buildConfig`, `imageStream`, `replicationController`,
+   `persistentVolumeClaim` for *Openshift*, other objects like `build`, `imageStreamTag`, `imageStreamImage`,
+   `event`, `node`, `pod`, `persistentVolume`,  are not exported at the moment.
  - Everything is exported as single artifacts containing everything.
  - ~~If you have images in internal OpenShift Docker registry,
 you have to manually export them to accessible registry and update artifact.~~

--- a/openshift2nulecule/openshift.py
+++ b/openshift2nulecule/openshift.py
@@ -122,8 +122,7 @@ class OpenshiftClient(object):
                              "buildConfig",
                              "imageStream",
                              "service",
-                             "persistentVolumeClaim",
-                             "route"]
+                             "persistentVolumeClaim"]
 
             # output of this export is kind List
             args = ["export", ",".join(resources), "-o", "json"]


### PR DESCRIPTION
This fixes #43.
There are problems with exporting routes. When moved to another
project on same cluster there might be collisions. When moved to
another cluster, router will be configured to use another hostname
so old one is not going to work.