### PR TITLE
Add MANIFEST file to include different file to tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include README.md MANIFEST.in requirements.txt Dockerfile CHANGELOG.md LICENSE
+recursive-include docs *
+recursive-include tests *


### PR DESCRIPTION
This file is required to add `README.md MANIFEST.in requirements.txt Dockerfile CHANGELOG.md LICENSE` files and `docs test` directory when a user try to create tarball using `python setup.py sdist` (which is also a standard way to create tarballs.
